### PR TITLE
Redesign the language fallback system

### DIFF
--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -58,6 +58,7 @@ function LanguagePicker(lang = 'en', config = {}) {
 LanguagePicker.prototype.newProcessor = function newProcessor() {
   let firstChoiceValue;
   const prefixedEnglish = this.prefix ? `${this.prefix}en` : 'en';
+  const prefixedLangScript = `-${this.langScript}`;
 
   return {
     addValue: (lang, value) => {
@@ -72,8 +73,9 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
 
       // Get the best value from the best language fallback:
       // 1. Requested language
-      if (this.values[this.userLang]) {
-        return this.values[this.userLang];
+      val = this.values[this.userLang];
+      if (val) {
+        return val;
       }
 
       // 2. Fallback language from fallbacks.json
@@ -87,7 +89,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // 3. Any language with suffix of same script as requested language
       const valueLangCodes = Object.keys(this.values);
       for (const langCode of valueLangCodes) {
-        if (langCode.endsWith(`-${this.langScript}`)) {
+        if (langCode.endsWith(prefixedLangScript)) {
           return this.values[langCode];
         }
       }

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -114,13 +114,19 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       if (this.langScript !== 'Latn') {
         for (const langCode of valueLangCodes) {
           // Latin or Romanized
-          if (
-            langCode.endsWith('-Latn') ||
-            langCode.endsWith('_rm') ||
-            langCode === 'zh_pinyin'
-          ) {
+          if (langCode.endsWith('-Latn')) {
             return this.values[langCode];
           }
+        }
+      }
+
+      // 7. Look for known latinized codes
+      // - Suffix of -rm
+      // - Code 'zh_pinyin'
+      for (const langCode of valueLangCodes) {
+        // Latin or Romanized
+        if (langCode.endsWith('_rm') || langCode === 'zh_pinyin') {
+          return this.values[langCode];
         }
       }
 

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -67,7 +67,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       }
     },
     getResult: () => {
-      const valueLangCodes = Object.keys(this.values);
+      let val;
 
       // Get the best value from the best language fallback:
       // 1. Requested language
@@ -76,43 +76,48 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       }
 
       // 2. Fallback language from fallbacks.json
-      for (let i = 0; i < this.fallbacks.length; i++) {
-        if (this.values[this.fallbacks[i]]) {
-          return this.values[this.fallbacks[i]];
+      for (const fallback of this.fallbacks) {
+        val = this.values[fallback];
+        if (val) {
+          return val;
         }
       }
 
       // 3. Any language with suffix of same script as requested language
-      for (let i = 0; i < valueLangCodes.length; i++) {
-        if (valueLangCodes[i].endsWith(this.langScript)) {
-          return this.values[valueLangCodes[i]];
+      const valueLangCodes = Object.keys(this.values);
+      for (const langCode of valueLangCodes) {
+        val = this.values[langCode];
+        if (val && langCode.endsWith(this.langScript)) {
+          return val;
         }
       }
 
       // 4. Another language with the same script
-      for (let i = 0; i < this.languagesInScript.length; i++) {
-        if (this.values[this.languagesInScript[i]]) {
-          return this.values[this.languagesInScript[i]];
+      for (const langCode of this.languagesInScript) {
+        val = this.values[langCode];
+        if (val) {
+          return val;
         }
       }
 
       // 5. English
-      if (this.values[this.prefix ? `${this.prefix}en` : 'en']) {
-        return this.values[this.prefix ? `${this.prefix}en` : 'en'];
+      val = this.values[this.prefix ? `${this.prefix}en` : 'en'];
+      if (val) {
+        return val;
       }
 
       // 6. Any language with suffix 'Latn'
       // Only do this if the script isn't already latin;
       // otherwise, we've done it in step 3
-      for (let i = 0; i < valueLangCodes.length; i++) {
-        if (valueLangCodes[i].endsWith('Latn')) {
-          return this.values[valueLangCodes[i]];
+      for (const value of valueLangCodes) {
+        if (value && value.endsWith('Latn')) {
+          return this.values[value];
         }
       }
 
       // If nothing is found:
       // - If there's a name tag, return it
-      // - IF there's no name tag, return first choice
+      // - If there's no name tag, return first choice
       return this.nameTag && this.values[this.nameTag] ?
         this.values[this.nameTag] :
         firstChoiceValue;

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -87,7 +87,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // 3. Any language with suffix of same script as requested language
       const valueLangCodes = Object.keys(this.values);
       for (const langCode of valueLangCodes) {
-        if (langCode.endsWith(this.langScript)) {
+        if (langCode.endsWith(`-${this.langScript}`)) {
           return this.values[langCode];
         }
       }
@@ -110,7 +110,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // Only do this if the script isn't already latin;
       // otherwise, we've done it in step 3
       for (const langCode of valueLangCodes) {
-        if (langCode.endsWith('Latn')) {
+        if (langCode.endsWith('-Latn')) {
           return this.values[langCode];
         }
       }
@@ -118,8 +118,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // If nothing is found:
       // - If there's a name tag, return it
       // - If there's no name tag, return first choice
-      val = this.values[this.nameTag];
-      return this.nameTag && val ? val : firstChoiceValue;
+      return (this.nameTag && this.values[this.nameTag]) || firstChoiceValue;
     },
   };
 };

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -57,6 +57,7 @@ function LanguagePicker(lang = 'en', config = {}) {
 
 LanguagePicker.prototype.newProcessor = function newProcessor() {
   let firstChoiceValue;
+  const prefixedEnglish = this.prefix ? `${this.prefix}en` : 'en';
 
   return {
     addValue: (lang, value) => {
@@ -86,9 +87,8 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // 3. Any language with suffix of same script as requested language
       const valueLangCodes = Object.keys(this.values);
       for (const langCode of valueLangCodes) {
-        val = this.values[langCode];
-        if (val && langCode.endsWith(this.langScript)) {
-          return val;
+        if (langCode.endsWith(this.langScript)) {
+          return this.values[langCode];
         }
       }
 
@@ -101,7 +101,7 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       }
 
       // 5. English
-      val = this.values[this.prefix ? `${this.prefix}en` : 'en'];
+      val = this.values[prefixedEnglish];
       if (val) {
         return val;
       }
@@ -109,21 +109,18 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // 6. Any language with suffix 'Latn'
       // Only do this if the script isn't already latin;
       // otherwise, we've done it in step 3
-      for (const value of valueLangCodes) {
-        if (value && value.endsWith('Latn')) {
-          return this.values[value];
+      for (const langCode of valueLangCodes) {
+        if (langCode.endsWith('Latn')) {
+          return this.values[langCode];
         }
       }
 
       // If nothing is found:
       // - If there's a name tag, return it
       // - If there's no name tag, return first choice
-      return this.nameTag && this.values[this.nameTag] ?
-        this.values[this.nameTag] :
-        firstChoiceValue;
+      val = this.values[this.nameTag];
+      return this.nameTag && val ? val : firstChoiceValue;
     },
-    // This is for testing purposes
-    getFallbacks: () => this.fallbacks,
   };
 };
 

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -2,11 +2,11 @@ const ls = require('language-scripts');
 const dataOverrides = require('./overrides.json');
 
 function LanguagePicker(lang = 'en', config = {}) {
-  let found = false;
   let scripts; // eslint-disable-line no-unused-vars
   let relevantScripts; // eslint-disable-line no-unused-vars
   let fallbackMap = {};
   let fallbacks = [];
+  const languagePerScript = {};
 
   this.nameTag = config.nameTag;
   // The prefix is either given or is the nameTag
@@ -24,19 +24,29 @@ function LanguagePicker(lang = 'en', config = {}) {
   // Use the given language as first choice
   fallbacks = [lang].concat(fallbacks);
 
-  // Fallback on common script
+  // Fallback on a language that shares the common script
   // eslint-disable-next-line prefer-const
   scripts = ls.adjust({ override: dataOverrides });
-  // Check for fallback script on each of the fallback lang
-  // until one is found
-  fallbacks.forEach((fbLang) => {
-    if (!found && scripts[fbLang]) {
-      relevantScripts = Array.isArray(scripts[fbLang]) ?
-        scripts[fbLang] : [scripts[fbLang]];
-      fallbacks = fallbacks.concat(scripts[fbLang]);
-      found = true;
-    }
+
+  // Create a map of languages per script so we can
+  // quickly extract
+  Object.keys(scripts).forEach((code) => {
+    const langScript = scripts[code];
+    languagePerScript[langScript] = languagePerScript[langScript] || [];
+    languagePerScript[langScript].push(code);
   });
+
+  // Add fallbacks from languages that use the same script
+  if (
+    languagePerScript[scripts[lang]] &&
+    languagePerScript[scripts[lang]].length > 0
+  ) {
+    // limit to 10 language fallbacks
+    // TODO: Ideally, the list of languages should also be
+    // prioritized, somehow
+    fallbacks = fallbacks.concat(languagePerScript[scripts[lang]].slice(0, 10));
+  }
+
 
   // Fallback to English
   if (fallbacks.indexOf('en') === -1) {

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -1,5 +1,10 @@
+const ls = require('language-scripts');
+const dataOverrides = require('./overrides.json');
 
 function LanguagePicker(lang = 'en', config = {}) {
+  let found = false;
+  let scripts; // eslint-disable-line no-unused-vars
+  let relevantScripts; // eslint-disable-line no-unused-vars
   let fallbackMap = {};
   let fallbacks = [];
 
@@ -19,6 +24,20 @@ function LanguagePicker(lang = 'en', config = {}) {
   // Use the given language as first choice
   fallbacks = [lang].concat(fallbacks);
 
+  // Fallback on common script
+  // eslint-disable-next-line prefer-const
+  scripts = ls.adjust({ override: dataOverrides });
+  // Check for fallback script on each of the fallback lang
+  // until one is found
+  fallbacks.forEach((fbLang) => {
+    if (!found && scripts[fbLang]) {
+      relevantScripts = Array.isArray(scripts[fbLang]) ?
+        scripts[fbLang] : [scripts[fbLang]];
+      fallbacks = fallbacks.concat(scripts[fbLang]);
+      found = true;
+    }
+  });
+
   // Fallback to English
   if (fallbacks.indexOf('en') === -1) {
     fallbacks.push('en');
@@ -28,6 +47,9 @@ function LanguagePicker(lang = 'en', config = {}) {
   if (this.nameTag) {
     fallbacks.push(this.nameTag);
   }
+
+  // Remove duplicates
+  fallbacks = fallbacks.filter((item, i) => fallbacks.indexOf(item) === i);
 
   // Add prefix to all languages if exists
   // eslint-disable-next-line arrow-body-style
@@ -63,6 +85,8 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
     getResult: () => bestChoiceValue ||
         (bestChoiceLang && fallbacks[bestChoiceLang]) ||
         firstChoiceValue,
+    // This is for testing purposes
+    getFallbacks: () => this.fallbacks,
   };
 };
 

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -111,15 +111,22 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
       // 6. Any language with suffix 'Latn'
       // Only do this if the script isn't already latin;
       // otherwise, we've done it in step 3
-      for (const langCode of valueLangCodes) {
-        if (langCode.endsWith('-Latn')) {
-          return this.values[langCode];
+      if (this.langScript !== 'Latn') {
+        for (const langCode of valueLangCodes) {
+          // Latin or Romanized
+          if (
+            langCode.endsWith('-Latn') ||
+            langCode.endsWith('_rm') ||
+            langCode === 'zh_pinyin'
+          ) {
+            return this.values[langCode];
+          }
         }
       }
 
       // If nothing is found:
       // - If there's a name tag, return it
-      // - If there's no name tag, return first choice
+      // - Otherwise, return first choice
       return (this.nameTag && this.values[this.nameTag]) || firstChoiceValue;
     },
   };

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -2,20 +2,38 @@ const ls = require('language-scripts');
 const dataOverrides = require('./overrides.json');
 
 function LanguagePicker(lang = 'en', config = {}) {
-  let scripts; // eslint-disable-line no-unused-vars
-  let relevantScripts; // eslint-disable-line no-unused-vars
   let fallbackMap = {};
   let fallbacks = [];
-  const languagePerScript = {};
+  const scripts = ls.adjust({ override: dataOverrides });
 
+  this.userLang = lang;
+  this.values = {};
   this.nameTag = config.nameTag;
   // The prefix is either given or is the nameTag
   // with an underscore
   // See Babel.js#24
   this.prefix = config.multiTag || (this.nameTag && `${this.nameTag}_`) || '';
-  fallbackMap = config.languageMap || {};
+
+
+  // Store language script
+  this.langScript = scripts[lang] || 'Latn';
+  // Collect languages that have the same script as requested language
+  this.languagesInScript = [];
+  Object.keys(scripts).forEach((code) => {
+    const langScript = scripts[code];
+    if (langScript === this.langScript) {
+      this.languagesInScript.push(code);
+    }
+  });
+
+  // Add prefix to all languages if exists
+  // eslint-disable-next-line arrow-body-style
+  this.languagesInScript = this.languagesInScript.map((code) => {
+    return code === this.nameTag ? code : this.prefix + code;
+  });
 
   // Add known fallbacks for the language
+  fallbackMap = config.languageMap || {};
   if (fallbackMap[lang]) {
     fallbacks = Array.isArray(fallbackMap[lang]) ?
       fallbackMap[lang] : [fallbackMap[lang]];
@@ -23,40 +41,6 @@ function LanguagePicker(lang = 'en', config = {}) {
 
   // Use the given language as first choice
   fallbacks = [lang].concat(fallbacks);
-
-  // Fallback on a language that shares the common script
-  // eslint-disable-next-line prefer-const
-  scripts = ls.adjust({ override: dataOverrides });
-
-  // Create a map of languages per script so we can
-  // quickly extract
-  Object.keys(scripts).forEach((code) => {
-    const langScript = scripts[code];
-    languagePerScript[langScript] = languagePerScript[langScript] || [];
-    languagePerScript[langScript].push(code);
-  });
-
-  // Add fallbacks from languages that use the same script
-  if (
-    languagePerScript[scripts[lang]] &&
-    languagePerScript[scripts[lang]].length > 0
-  ) {
-    // limit to 10 language fallbacks
-    // TODO: Ideally, the list of languages should also be
-    // prioritized, somehow
-    fallbacks = fallbacks.concat(languagePerScript[scripts[lang]].slice(0, 10));
-  }
-
-
-  // Fallback to English
-  if (fallbacks.indexOf('en') === -1) {
-    fallbacks.push('en');
-  }
-
-  // Fallback to nameTag
-  if (this.nameTag) {
-    fallbacks.push(this.nameTag);
-  }
 
   // Remove duplicates
   fallbacks = fallbacks.filter((item, i) => fallbacks.indexOf(item) === i);
@@ -67,34 +51,72 @@ function LanguagePicker(lang = 'en', config = {}) {
     return code === this.nameTag ? code : this.prefix + code;
   });
 
+  // Store initial fallbacks
   this.fallbacks = fallbacks;
 }
 
 LanguagePicker.prototype.newProcessor = function newProcessor() {
-  const { fallbacks, nameTag, prefix } = this;
-  let bestChoiceLang = nameTag || (prefix ? `${prefix}en` : 'en');
-  let bestChoiceValue;
   let firstChoiceValue;
 
   return {
-    addValue(lang, value) {
-      const langIndex = fallbacks.indexOf(lang);
-      if (
-        langIndex > -1 &&
-        langIndex <= fallbacks.indexOf(bestChoiceLang)
-      ) {
-        // Given language is a better fallback
-        bestChoiceLang = lang;
-        bestChoiceValue = value;
+    addValue: (lang, value) => {
+      this.values[lang] = value;
+
+      if (!firstChoiceValue) {
+        firstChoiceValue = value;
+      }
+    },
+    getResult: () => {
+      const valueLangCodes = Object.keys(this.values);
+
+      // Get the best value from the best language fallback:
+      // 1. Requested language
+      if (this.values[this.userLang]) {
+        return this.values[this.userLang];
       }
 
-      // Store the value of the first value given
-      firstChoiceValue = firstChoiceValue !== undefined ?
-        firstChoiceValue : value;
+      // 2. Fallback language from fallbacks.json
+      for (let i = 0; i < this.fallbacks.length; i++) {
+        if (this.values[this.fallbacks[i]]) {
+          return this.values[this.fallbacks[i]];
+        }
+      }
+
+      // 3. Any language with suffix of same script as requested language
+      for (let i = 0; i < valueLangCodes.length; i++) {
+        if (valueLangCodes[i].endsWith(this.langScript)) {
+          return this.values[valueLangCodes[i]];
+        }
+      }
+
+      // 4. Another language with the same script
+      for (let i = 0; i < this.languagesInScript.length; i++) {
+        if (this.values[this.languagesInScript[i]]) {
+          return this.values[this.languagesInScript[i]];
+        }
+      }
+
+      // 5. English
+      if (this.values[this.prefix ? `${this.prefix}en` : 'en']) {
+        return this.values[this.prefix ? `${this.prefix}en` : 'en'];
+      }
+
+      // 6. Any language with suffix 'Latn'
+      // Only do this if the script isn't already latin;
+      // otherwise, we've done it in step 3
+      for (let i = 0; i < valueLangCodes.length; i++) {
+        if (valueLangCodes[i].endsWith('Latn')) {
+          return this.values[valueLangCodes[i]];
+        }
+      }
+
+      // If nothing is found:
+      // - If there's a name tag, return it
+      // - IF there's no name tag, return first choice
+      return this.nameTag && this.values[this.nameTag] ?
+        this.values[this.nameTag] :
+        firstChoiceValue;
     },
-    getResult: () => bestChoiceValue ||
-        (bestChoiceLang && fallbacks[bestChoiceLang]) ||
-        firstChoiceValue,
     // This is for testing purposes
     getFallbacks: () => this.fallbacks,
   };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@kartotherian/err": "^0.0.3",
     "@kartotherian/input-validator": "^0.0.6",
+    "language-scripts": "^1.0.2",
     "bluebird": "^3.5.1",
     "pbf": "^3.1.0",
     "tilelive-promise": "^2.0.0",

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -147,6 +147,75 @@ describe('LanguagePicker: Pick the correct language', () => {
       ],
       expected: 'en value',
     },
+    {
+      msg: 'Russian has no value and no fallback defined;' +
+        'get value from a language that has -Cyrl over value in English',
+      langCode: 'ru',
+      values: [
+        { sah: 'sah value' }, // Same alphabet
+        { 'foo-Cyrl': 'foo-Cyrl value' },
+        { en: 'en value' },
+      ],
+      expected: 'foo-Cyrl value',
+    },
+    {
+      msg: 'Russian has no value and no fallback defined;' +
+        'no value with -Cyrl, get value from a language that uses the same script over value in English',
+      langCode: 'ru',
+      values: [
+        { sah: 'sah value' }, // Same alphabet
+        { 'foo-Arab': 'foo-Arab value' },
+        { en: 'en value' },
+      ],
+      expected: 'sah value',
+    },
+    {
+      msg: 'Hebrew has no value, no fallback defined,' +
+        ' no other language with -Hebr suffix,' +
+        ' and no English value; get value from any language that has -Latn',
+      langCode: 'he',
+      values: [
+        { sah: 'sah value' },
+        { 'zh-Latn': 'zh-Latn value' },
+        { 'bar-Cyrl': 'bar-Cyrl value' },
+      ],
+      expected: 'zh-Latn value',
+    },
+    {
+      msg: 'Arabic has no value, no fallback defined, ' +
+        'no other language with -Arab suffix, ' +
+        'no English value, ' +
+        'no value from any language that has -Arab, ' +
+        'no language with -Latn; ' +
+        'Get local value.',
+      langCode: 'ar',
+      config: {
+        nameTag: 'name',
+      },
+      values: [
+        { fr: 'fr value' },
+        { 'zh-Hebr': 'zh-Hebr value' },
+        { 'bar-Cyrl': 'bar-Cyrl value' },
+        { name: 'name value' },
+      ],
+      expected: 'name value',
+    },
+    {
+      msg: 'Arabic has no value, no fallback defined, ' +
+        'no other language with -Arab suffix, ' +
+        'no English value, ' +
+        'no value from any language that has -Arab, ' +
+        'no language with -Latn; ' +
+        'there is no local value (no nametag);' +
+        'get first value',
+      langCode: 'ar',
+      values: [
+        { fr: 'fr value' },
+        { 'zh-Hebr': 'zh-Hebr value' },
+        { 'bar-Cyrl': 'bar-Cyrl value' },
+      ],
+      expected: 'fr value',
+    },
   ];
 
   cases.forEach((data) => {
@@ -163,45 +232,6 @@ describe('LanguagePicker: Pick the correct language', () => {
     it(data.msg, () => {
       assert.equal(
         lpp.getResult(),
-        data.expected
-      );
-    });
-  });
-});
-
-describe('LanguagePicker: Build a correct fallback list', () => {
-  const cases = [
-    {
-      msg: 'Spanish falls back to a Latn language',
-      langCode: 'es',
-      expected: ['es', 'aa', 'abr', 'ace', 'ach', 'ada', 'af', 'agq', 'ak', 'akz', 'ale', 'en'],
-    },
-    {
-      msg: 'Language with a fallback and script fallbacks',
-      langCode: 'yi',
-      config: {
-        languageMap: {
-          yi: 'he', // From fallbacks.json
-          other: 'languages',
-          that: 'dont',
-          matter: 'at all',
-        },
-      },
-      // Languages with 'Hebr' script come after the
-      // official fallback (and there are only 5 languages
-      // using the Hebr script)
-      expected: ['yi', 'he', 'jpr', 'jrb', 'lad', 'en'],
-    },
-  ];
-
-  cases.forEach((data) => {
-    const lp = new LanguagePicker(data.langCode, data.config);
-    const lpp = lp.newProcessor();
-
-    // Check the result
-    it(data.msg, () => {
-      assert.deepStrictEqual(
-        lpp.getFallbacks(),
         data.expected
       );
     });

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -174,7 +174,7 @@ describe('LanguagePicker: Build a correct fallback list', () => {
     {
       msg: 'Spanish falls back to a Latn language',
       langCode: 'es',
-      expected: ['es', 'aa', 'abr', 'ace', 'ach', 'ada', 'en'],
+      expected: ['es', 'aa', 'abr', 'ace', 'ach', 'ada', 'af', 'agq', 'ak', 'akz', 'ale', 'en'],
     },
     {
       msg: 'Language with a fallback and script fallbacks',
@@ -188,7 +188,8 @@ describe('LanguagePicker: Build a correct fallback list', () => {
         },
       },
       // Languages with 'Hebr' script come after the
-      // official fallback
+      // official fallback (and there are only 5 languages
+      // using the Hebr script)
       expected: ['yi', 'he', 'jpr', 'jrb', 'lad', 'en'],
     },
   ];

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -182,6 +182,34 @@ describe('LanguagePicker: Pick the correct language', () => {
       expected: 'zh-Latn value',
     },
     {
+      msg: 'Hebrew has no value, no fallback defined,' +
+        ' no other language with -Hebr suffix,' +
+        ' no English value;' +
+        ' no value from any language that has -Latn;' +
+        ' show language with zh_pinyin value',
+      langCode: 'he',
+      values: [
+        { sah: 'sah value' },
+        { zh_pinyin: 'zh_pinyin value' },
+        { 'bar-Cyrl': 'bar-Cyrl value' },
+      ],
+      expected: 'zh_pinyin value',
+    },
+    {
+      msg: 'Hebrew has no value, no fallback defined,' +
+        ' no other language with -Hebr suffix,' +
+        ' no English value;' +
+        ' no value from any language that has -Latn;' +
+        ' show language with _rm suffix',
+      langCode: 'he',
+      values: [
+        { sah: 'sah value' },
+        { jp_rm: 'jp_rm value' },
+        { 'bar-Cyrl': 'bar-Cyrl value' },
+      ],
+      expected: 'jp_rm value',
+    },
+    {
       msg: 'Arabic has no value, no fallback defined, ' +
         'no other language with -Arab suffix, ' +
         'no English value, ' +

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -147,45 +147,6 @@ describe('LanguagePicker: Pick the correct language', () => {
       ],
       expected: 'en value',
     },
-    /* Script overrides */
-    {
-      msg: 'Fallback to language script be-tarask -> Cyrl',
-      langCode: 'be-tarask',
-      config: {
-        languageMap: {
-          foo: 'bar',
-          other: 'languages',
-          that: 'dont',
-          matter: 'at all',
-        },
-      },
-      values: [
-        { en: 'en value' },
-        { he: 'he value' },
-        { es: 'es value' },
-        { Cyrl: 'Cyrl value' },
-      ],
-      expected: 'Cyrl value',
-    },
-    {
-      msg: 'Fallback to language script zh -> Hans',
-      langCode: 'zh',
-      config: {
-        languageMap: {
-          foo: 'bar',
-          other: 'languages',
-          that: 'dont',
-          matter: 'at all',
-        },
-      },
-      values: [
-        { en: 'en value' },
-        { he: 'he value' },
-        { es: 'es value' },
-        { Hans: 'Hans value' },
-      ],
-      expected: 'Hans value',
-    },
   ];
 
   cases.forEach((data) => {
@@ -211,19 +172,12 @@ describe('LanguagePicker: Pick the correct language', () => {
 describe('LanguagePicker: Build a correct fallback list', () => {
   const cases = [
     {
-      msg: 'Spanish falls back to Latn',
+      msg: 'Spanish falls back to a Latn language',
       langCode: 'es',
-      config: {
-        languageMap: {
-          other: 'languages',
-          that: 'dont',
-          matter: 'at all',
-        },
-      },
-      expected: ['es', 'Latn', 'en'],
+      expected: ['es', 'aa', 'abr', 'ace', 'ach', 'ada', 'en'],
     },
     {
-      msg: 'Language with a fallback; the script comes from the main language',
+      msg: 'Language with a fallback and script fallbacks',
       langCode: 'yi',
       config: {
         languageMap: {
@@ -233,24 +187,9 @@ describe('LanguagePicker: Build a correct fallback list', () => {
           matter: 'at all',
         },
       },
-      // language_scripts yi -> Hebr
-      // Should find 'Hebr' from 'yi' directly
-      expected: ['yi', 'he', 'Hebr', 'en'],
-    },
-    {
-      msg: 'Language with a fallback; the script comes from the fallback',
-      langCode: 'aeb-arab',
-      config: {
-        languageMap: {
-          'aeb-arab': 'ar', // From fallbacks.json
-          other: 'languages',
-          that: 'dont',
-          matter: 'at all',
-        },
-      },
-      // language_scripts ar -> Arab
-      // Should find 'Arab' from the fallback 'ar'
-      expected: ['aeb-arab', 'ar', 'Arab', 'en'],
+      // Languages with 'Hebr' script come after the
+      // official fallback
+      expected: ['yi', 'he', 'jpr', 'jrb', 'lad', 'en'],
     },
   ];
 

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -148,7 +148,7 @@ describe('LanguagePicker: Pick the correct language', () => {
       expected: 'en value',
     },
     {
-      msg: 'Russian has no value and no fallback defined;' +
+      msg: 'Russian has no value and no fallback defined; ' +
         'get value from a language that has -Cyrl over value in English',
       langCode: 'ru',
       values: [
@@ -159,7 +159,7 @@ describe('LanguagePicker: Pick the correct language', () => {
       expected: 'foo-Cyrl value',
     },
     {
-      msg: 'Russian has no value and no fallback defined;' +
+      msg: 'Russian has no value and no fallback defined; ' +
         'no value with -Cyrl, get value from a language that uses the same script over value in English',
       langCode: 'ru',
       values: [


### PR DESCRIPTION
Fallback on languages now has the following rules, in order,
when checking and prioritizing existing values:

1. Requested language
2. Fallback language from fallbacks.json
3. Local language with suffix of same script as requested language
4. Any language with the same script as requested language
5. English
6. Any language with suffix Latn
7. Local language (name tag)
8. First value given