### PR TITLE
Add an option to force display in local language; add documentation

### DIFF
--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -37,7 +37,7 @@ function LanguagePicker(lang = 'en', config = {}) {
 
   if (this.forceLocal) {
     // If we are forcing a local language, we don't need
-    // any of the fallack calculations
+    // any of the fallback calculations
     return;
   }
   // Store language script

--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -1,6 +1,29 @@
 const ls = require('language-scripts');
 const dataOverrides = require('./overrides.json');
 
+/**
+ * Define a language picker with fallback rules.
+ *
+ * @param {String} [lang='en'] Requested language.
+ * @param {Object} [config] Optional configuration object
+ * @cfg {string} [nameTag] A tag that defines the local value in a label.
+ *  If specified, will also be used as the prefix for other languages if
+ *  a prefix is not already specified with `multiTag`.
+ * @cfg {string} [multiTag] A specified prefix for the language keys
+ * @cfg {Object} [languageMap] An object representing language fallbacks; languages
+ *  may have more than one fallback, represented in a string or an array of strings.
+ *  Example:
+ *  {
+ *    'langA': [ 'lang1', 'lang2' ]
+ *    'langB': 'lang3'
+ *  }
+ * @cfg {boolean} [forceLocal] Force the system to fetch a local representation
+ *  of the labels, if it exists. This will only work if there is a nameTag specified,
+ *  since that tag dictates the key of the local value. If the value doesn't exist
+ *  or if the nameTag is not specified, the system will return the first value given.
+ *  Note: All fallbacks are skipped if this parameter is truthy!
+ * @constructor
+ */
 function LanguagePicker(lang = 'en', config = {}) {
   const scripts = ls.adjust({ override: dataOverrides });
 
@@ -10,7 +33,13 @@ function LanguagePicker(lang = 'en', config = {}) {
   // with an underscore
   // See Babel.js#24
   this.prefix = config.multiTag || (this.nameTag && `${this.nameTag}_`) || '';
+  this.forceLocal = !!config.forceLocal;
 
+  if (this.forceLocal) {
+    // If we are forcing a local language, we don't need
+    // any of the fallack calculations
+    return;
+  }
   // Store language script
   this.langScript = scripts[lang] || 'Latn';
   // Collect languages that have the same script as requested language
@@ -59,6 +88,17 @@ function LanguagePicker(lang = 'en', config = {}) {
   this.prefixedLangScript = `-${this.langScript}`;
 }
 
+/**
+ * Create a processor for analyzing the values of a label
+ *
+ * @return {Object}
+ * @return {Function} return.addValue Add a label language/value pair
+ *  to this label consideration. Accepts string parameters 'lang' and 'value'
+ *  for the pair.
+ * @return {Function} return.getResult Get the best value from the stored
+ *  language/value pairs for the label, according to the fallback consideration
+ *  of the requested language.
+ */
 LanguagePicker.prototype.newProcessor = function newProcessor() {
   // These variables are the only "per-processor" state
   // The processor must not modify any this.* values
@@ -73,58 +113,60 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
         firstFoundValue = value;
       }
     },
-
     getResult: () => {
       let result;
 
-      // Get the best value from the best language fallback:
-      // 1. Requested language
-      result = values[this.userLang];
-      if (result) {
-        return result;
-      }
-
-      // 2. Fallback language from fallbacks.json
-      for (const fallback of this.fallbacks) {
-        result = values[fallback];
+      if (!this.forceLocal) {
+        // Get the best value from the best language fallback:
+        // 1. Requested language
+        result = values[this.userLang];
         if (result) {
           return result;
         }
-      }
 
-      // 3. Any language with suffix of same script as requested language
-      const valueLangCodes = Object.keys(values);
-      for (const langCode of valueLangCodes) {
-        if (langCode.endsWith(this.prefixedLangScript)) {
-          return values[langCode];
+        // 2. Fallback language from fallbacks.json
+        for (const fallback of this.fallbacks) {
+          result = values[fallback];
+          if (result) {
+            return result;
+          }
         }
-      }
 
-      // 4. Another language with the same script
-      for (const langCode of this.languagesInScript) {
-        result = values[langCode];
-        if (result) {
-          return result;
-        }
-      }
-
-      // 5. If we requested a language that is in Latin script
-      // let's try to latinize the content. We only do that if
-      // the requested language is Latin already; Otherwise
-      // we want to fallback to the local script instead of
-      // assuming latinization is expected
-      if (this.langScript === 'Latn') {
-        // 5. Look for known latinized codes
-        // - Suffix of _rm
-        // - Code 'zh_pinyin'
+        // 3. Any language with suffix of same script as requested language
+        const valueLangCodes = Object.keys(values);
         for (const langCode of valueLangCodes) {
-          // Romanized or Chinese Pinyin
-          if (langCode.endsWith('_rm') || langCode === 'zh_pinyin') {
+          if (langCode.endsWith(this.prefixedLangScript)) {
             return values[langCode];
           }
         }
+
+        // 4. Another language with the same script
+        for (const langCode of this.languagesInScript) {
+          result = values[langCode];
+          if (result) {
+            return result;
+          }
+        }
+
+        // 5. If we requested a language that is in Latin script
+        // let's try to latinize the content. We only do that if
+        // the requested language is Latin already; Otherwise
+        // we want to fallback to the local script instead of
+        // assuming latinization is expected
+        if (this.langScript === 'Latn') {
+          // 5. Look for known latinized codes
+          // - Suffix of _rm
+          // - Code 'zh_pinyin'
+          for (const langCode of valueLangCodes) {
+            // Romanized or Chinese Pinyin
+            if (langCode.endsWith('_rm') || langCode === 'zh_pinyin') {
+              return values[langCode];
+            }
+          }
+        }
       }
-      // If nothing is found:
+
+      // If nothing is found or if we are forcing local language:
       // - If there's a name tag, return it
       // - Otherwise, return the first found value
       return (this.nameTag && values[this.nameTag]) || firstFoundValue;

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -265,6 +265,46 @@ describe('LanguagePicker: Pick the correct language', () => {
       ],
       expected: 'fr value',
     },
+    {
+      msg: 'Force local language, even if the requested language exists in values',
+      config: {
+        nameTag: 'name',
+        forceLocal: true,
+      },
+      langCode: 'fr',
+      values: [
+        { name_fr: 'fr value' },
+        { name_ar: 'ar value' },
+        { name: 'name value' },
+      ],
+      expected: 'name value',
+    },
+    {
+      msg: 'Force local language, without a requested language at all',
+      config: {
+        nameTag: 'name',
+        forceLocal: true,
+      },
+      values: [
+        { name_fr: 'fr value' },
+        { name_ar: 'ar value' },
+        { name: 'name value' },
+      ],
+      expected: 'name value',
+    },
+    {
+      msg: 'Force local language, without a requested language at all, and without local value; show first value',
+      config: {
+        nameTag: 'name',
+        forceLocal: true,
+      },
+      values: [
+        { name_fr: 'fr value' },
+        { name_ar: 'ar value' },
+        { name_foo: 'foo value' },
+      ],
+      expected: 'fr value',
+    },
   ];
 
   cases.forEach((data) => {

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -305,6 +305,19 @@ describe('LanguagePicker: Pick the correct language', () => {
       ],
       expected: 'fr value',
     },
+    {
+      msg: 'Force local language, without a nameTag set; show first value',
+      config: {
+        forceLocal: true,
+      },
+      langCode: 'en',
+      values: [
+        { fr: 'fr value' },
+        { en: 'en value' },
+        { ar: 'ar value' },
+      ],
+      expected: 'fr value',
+    },
   ];
 
   cases.forEach((data) => {


### PR DESCRIPTION
Add a config variable that forces the system to skip language or fallback selection and show the local representation regardless of requested language (or without having to specify requested language)