### PR TITLE
Add 'tyops' package to help with common typos

### DIFF
--- a/.typos.json
+++ b/.typos.json
@@ -1,0 +1,19 @@
+{
+  "caseSensitive": [
+    [ "@returns", "@return" ]
+  ],
+  "caseInsensitive": [
+    [ "falback", "fallback" ],
+    [ "fallack", "fallback" ],
+    [ "fallbak", "fallback" ],
+    [ "paralell", "parallel" ],
+    [ "properites", "properties" ],
+    [ "\bteh\b", "the" ],
+    [ "intialization", "initialization" ],
+    [ "durring", "during" ],
+    [ "contian", "contain" ],
+    [ "occured", "occurred" ],
+    [ "pgk", "pkg" ],
+    [ "overriden", "overridden" ]
+  ]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@ module.exports = function Gruntfile(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-tyops');
 
   grunt.initConfig({
     watch: {
@@ -19,6 +20,15 @@ module.exports = function Gruntfile(grunt) {
         ],
       },
     },
+    tyops: {
+      options: {
+        typos: '.typos.json',
+      },
+      src: [
+        '**/*.js',
+        '!node_modules/**',
+      ],
+    },
     mochaTest: {
       test: {
         options: {
@@ -30,6 +40,6 @@ module.exports = function Gruntfile(grunt) {
   });
 
   grunt.registerTask('lint', ['eslint']);
-  grunt.registerTask('test', ['mochaTest', 'lint']);
+  grunt.registerTask('test', ['tyops', 'lint', 'mochaTest']);
   grunt.registerTask('default', 'test');
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^20.1.0",
     "grunt-mocha-test": "^0.13.3",
+    "grunt-tyops": "0.1.0",
     "mocha": "^5.0.4",
     "typedarray-to-buffer": "*",
     "json-stringify-pretty-compact": "*",


### PR DESCRIPTION
Because apparently, I can't write 'fallbacks'.