### PR TITLE
Fix Norwegian fallbacks

### DIFF
--- a/lib/fallbacks.json
+++ b/lib/fallbacks.json
@@ -166,11 +166,21 @@
         "zh-hant"
     ],
     "nap": "it",
-    "nb": "nn",
+    "nb": [
+        "no",
+        "nn"
+    ],
     "nds": "de",
     "nds-nl": "nl",
     "nl-informal": "nl",
-    "nn": "nb",
+    "nn": [
+        "no",
+        "nb"
+    ],
+    "no": [
+        "nb",
+        "nn"
+    ],
     "nrm": "fr",
     "oc": [
         "ca",


### PR DESCRIPTION
OSM uses name:no for most labels, and uses name:nb and name:nn only
rarely. See https://wiki.openstreetmap.org/wiki/Multilingual_names#Norway

For this reason, make sure that nb and nn fall back to no.
Also make no fall back to nb and nn in that order (since more people use
nb than no).

Bug: https://phabricator.wikimedia.org/T194527