### PR TITLE
When looking for romanized languages, ignore Romansh (rm)

### DIFF
--- a/lib/LanguagePicker.js
+++ b/lib/LanguagePicker.js
@@ -135,9 +135,13 @@ LanguagePicker.prototype.newProcessor = function newProcessor() {
           // Look for known latinized codes
           // - Suffix of _rm
           // - Code 'zh_pinyin'
+          // Romanized or Chinese Pinyin
           for (const langCode of valueLangCodes) {
-            // Romanized or Chinese Pinyin
-            if (langCode.endsWith('_rm') || langCode === 'zh_pinyin') {
+            // Look for language that is romanized (xx_rm), but not
+            // specifically 'Romansh' which has the language code 'rm'
+            if ((langCode.endsWith('_rm') && langCode !== `${this.prefix}rm`) ||
+            langCode === 'zh_pinyin'
+            ) {
               return values[langCode];
             }
           }

--- a/test/langPickerTest.js
+++ b/test/langPickerTest.js
@@ -111,6 +111,26 @@ describe('LanguagePicker: Pick the correct language', () => {
       expected: 'foo-Latn value',
     },
     {
+      msg: 'Edge case: Values have value for "rm" which is also the suffix ' +
+        'we used when a -Latn lang is not found.',
+      // In essence, we need to make sure that when we fall back to looking for
+      // things that 'end with' _rm, we don't find 'rm' language
+      // (because name_rm fits the pattern) and only things that actually
+      // end up with name_langcode_rm
+      langCode: 'en', // English;
+      config: {
+        nameTag: 'name',
+        languageMap: { foo: 'bar' },
+      },
+      values: [
+        { name_baz: 'baz value' },
+        { name_rm: 'rm value which should not be picked' },
+        { name_quuz: 'quuz value' },
+        { name: 'default name value' },
+      ],
+      expected: 'default name value',
+    },
+    {
       msg: 'Latin language requested, no fallback exists, find romanized label with _rm suffix',
       langCode: 'es', // Spanish
       config: {


### PR DESCRIPTION
Since our prefix is 'name_xx', the lookup for languages that end
with _rm can also pick up 'name_rm' which isn't a romanized script
but rather the language "Romansh".

This changes the lookup fallback script to take that into account.

Fixes kartotherian/kartotherian#84